### PR TITLE
Added referee account number in defrayal form

### DIFF
--- a/includes/fonctions.inc.php
+++ b/includes/fonctions.inc.php
@@ -421,7 +421,9 @@ function getReferees($orderByLevel = false)
         $order = "";
     }
 
-    $refereesQuery = "SELECT idDbdPersonne AS id, nom, prenom, idArbitre AS niveau, arbitrePublic FROM DBDPersonne WHERE idArbitre > 1" . $order;
+    $refereesQuery = "SELECT idDbdPersonne AS id, nom, prenom, idArbitre AS niveau, arbitrePublic, numeroCompte
+                      FROM DBDPersonne
+                      WHERE idArbitre > 1" . $order;
     if (!$referessData = mysql_query($refereesQuery)) {
         $errorReferee = array();
         $errorReferee['idArbitre'] = 0;

--- a/styles/main.css
+++ b/styles/main.css
@@ -2499,8 +2499,10 @@ ul.EWCMatchesTypesKey {
     margin-left: 110px;
 }
 
-.adminForm input[readonly] {
-    background-color: #CCC;
+.adminForm input[readonly],
+.adminForm textarea[readonly] {
+    background-color: #eeeeee;
+    color: #777777;
 }
 
 .adminForm select {


### PR DESCRIPTION
Adding the account number of all referees in the defrayal list would clutter the UI and show too much private information in one screen. Therefore the account number was instead added in the form to add a defrayal.

Fixes #33 
